### PR TITLE
build-in-container:refactor code for user inputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@
 /build-in-container/ccache
 /build-in-container/logs
 /build-in-container/out
+/build-in-container/SPECS
 /build-in-container/toolkit

--- a/build-in-container/Dockerfile
+++ b/build-in-container/Dockerfile
@@ -42,5 +42,3 @@ RUN tdnf update -qy tdnf && \
                 rsync \
                 tar \
                 wget
-
-RUN echo "source /mariner/scripts/setup.sh" >> /root/.bashrc

--- a/build-in-container/README.md
+++ b/build-in-container/README.md
@@ -20,7 +20,7 @@ Optional arguments <br />
 - 'mariner_dir' refers to the directory with Mariner artifacts (SPECS, toolkit, etc.) <br/>
 - If mariner_dir is provided, it will be used for all Mariner artifacts like toolkit, SPECS, build, out and logs. Else, current directory will be used. <br />
 - Place specs to build under $mariner_dir/SPECS/ <br />
-- Please find [SPEC sample](https://github.com/microsoft/CBL-MarinerTutorials/tree/main/SPECS) here <br />
+- Please find SPEC sample [here](./../SPECS/hello_world_demo/) <br />
 - The output from the build will be available under $mariner_dir/out/ (RPMS and SRPMS) <br />
 - Logs are published under $mariner_dir/logs/ <br />
 
@@ -51,7 +51,7 @@ make build-packages SRPM_PACK_LIST="hello_world_demo" -j$(nproc)
 
 In the _build_ mode, it sets up the Mariner build system inside the container, builds all the specs under $mariner_dir/SPECS/ and outputs to $mariner_dir/out/.
 
-In the _interactive_ mode, it sets up the Mariner build system inside the container, and starts the container at /mariner/toolkit/. The user can invoke Mariner `make` commands to build packages, images and more. Please see the [section](https://github.com/microsoft/CBL-MarinerTutorials/tree/main/buildInContainer/build-in-container#sample-make-commands) for sample `make` commands, and visit [Mariner Docs](https://github.com/microsoft/CBL-Mariner/blob/2.0/toolkit/docs/building/building.md) for the complete set of commands. 
+In the _interactive_ mode, it sets up the Mariner build system inside the container, and starts the container at /mariner/toolkit/. The user can invoke Mariner `make` commands to build packages, images and more. Please see the [section](README.md#sample-make-commands) for sample `make` commands, and visit [Mariner Docs](https://github.com/microsoft/CBL-Mariner/blob/2.0/toolkit/docs/building/building.md) for the complete set of commands.
 
 ### Helper scripts
 

--- a/build-in-container/README.md
+++ b/build-in-container/README.md
@@ -6,11 +6,14 @@ Please install docker on your system before using the tool.
 ## Usage
 The mariner-docker-builder.sh script presents these options <br />
 <pre>
-  -t               creates container image <br />
-  -b [mariner_dir] creates container, builds specs under [mariner_dir]/SPECS/, & places output under [mariner_dir]/out/ <br />
-  -i [mariner_dir] creates an interactive Mariner build container <br />
-  -c [mariner_dir] cleans up Mariner workspace at [mariner_dir], container images and instances <br />
-  --help           shows help on usage <br />
+  -t                        creates container image <br />
+  -b                        creates container, builds specs under [mariner_dir]/SPECS/, & places output under [mariner_dir]/out/ <br />
+  -i                        creates an interactive Mariner build container <br />
+  -c                        cleans up Mariner workspace at [mariner_dir], container images and instances <br />
+  --help                    shows help on usage <br />
+
+Optional arguments <br />
+  --mariner_dir             directory to use for Mariner artifacts (SPECS, toolkit, ..). Default is the current directory <br />
 </pre>
 
 - 'tool_dir' refers to the directory of the build-in-container tool <br/>
@@ -34,6 +37,9 @@ ls out/RPMS/x86_64/
 ./CBL-MarinerTutorials/mariner-docker-builder.sh -i
 #  Run the tools manually
 make build-packages SRPM_PACK_LIST="hello_world_demo" -j$(nproc)
+
+# Provide optional arguments
+./CBL-MarinerTutorials/mariner-docker-builder.sh -i --mariner_dir /path/to/CBL-Mariner/
 ```
 
 ## Details on what goes on inside the container:

--- a/build-in-container/run-container.sh
+++ b/build-in-container/run-container.sh
@@ -17,7 +17,7 @@ run_build_container() {
         ${mount_pts} \
         --privileged \
         --cap-add SYS_ADMIN \
-        mcr.microsoft.com/mariner-container-build:2.0 /mariner/scripts/build-mariner.sh
+        mcr.microsoft.com/mariner-container-build:2.0 /mariner/scripts/build-mariner.sh $container_args
 }
 
 run_interactive_container() {
@@ -25,7 +25,7 @@ run_interactive_container() {
         ${mount_pts} \
         --privileged \
         --cap-add SYS_ADMIN \
-        -it mcr.microsoft.com/mariner-container-build:2.0 /bin/bash
+        -it mcr.microsoft.com/mariner-container-build:2.0 /mariner/scripts/build-mariner.sh $container_args
 }
 
 mount_pts="
@@ -124,6 +124,6 @@ mount_pts="
     -v /sys:/sys:ro
     "
 
-local container_type=("$@")
+container_args="--container_type $container_type"
 if [ "$container_type" == "build" ]; then run_build_container; return; fi
 if [ "$container_type" == "interactive" ]; then run_interactive_container; return; fi

--- a/build-in-container/scripts/build-mariner.sh
+++ b/build-in-container/scripts/build-mariner.sh
@@ -6,10 +6,31 @@
 set -e
 set -x
 
+# parse args passed to container
+while (( "$#" )); do
+    case "$1" in
+        --container_type)
+        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+            container_type=$2
+            shift 2
+        else
+            echo "Error: Argument for $1 is missing" >&2
+            exit 1
+        fi
+        ;;
+        -*|--*=) # unsupported flags
+        echo "Error: Unsupported flag $1" >&2
+        exit 1
+        ;;
+    esac
+done
+
 source /mariner/scripts/setup.sh
 
-# check if SPECS/ is empty
-if [ ! "$(ls -A $SPECS_DIR)" ]; then
-    exit
+if [[ "${container_type}" == "build" ]]; then
+    # exit if SPECS/ is empty
+    if [ ! "$(ls -A $SPECS_DIR)" ]; then exit; fi
+    source /mariner/scripts/build.sh
+else
+    /bin/bash
 fi
-source /mariner/scripts/build.sh


### PR DESCRIPTION
Changes in this PR:
Customer facing:
- change how user input is taken, so we can add more input options in the future. Earlier we treated the first optional user input as mariner_dir, but now, user must specify --mariner_dir flag before the input.

Backend:
- change parsing mechanism for optional arguments
- change the entrypoints in containers. Use the same entrypoint, and alter behavior inside the container based on container_type (build v/s interactive).