### PR TITLE
build-in-container: add custom repo, disable mariner default repos

### DIFF
--- a/build-in-container/README.md
+++ b/build-in-container/README.md
@@ -14,6 +14,9 @@ The mariner-docker-builder.sh script presents these options <br />
 
 Optional arguments <br />
   --mariner_dir             directory to use for Mariner artifacts (SPECS, toolkit, ..). Default is the current directory <br />
+  --RPM_repo_file           Path to a custom repo file. Please see [here](./README.md#sample-custom-repo) for sample custom repo file  <br />
+  --RPM_storage             URL of Azure blob storage to install RPMs from <br />
+  --disable_mariner_repo    Disable default Mariner RPM repos. They are enabled by default <br />
 </pre>
 
 - 'tool_dir' refers to the directory of the build-in-container tool <br/>
@@ -39,7 +42,7 @@ ls out/RPMS/x86_64/
 make build-packages SRPM_PACK_LIST="hello_world_demo" -j$(nproc)
 
 # Provide optional arguments
-./CBL-MarinerTutorials/mariner-docker-builder.sh -i --mariner_dir /path/to/CBL-Mariner/
+./CBL-MarinerTutorials/mariner-docker-builder.sh -i --mariner_dir /path/to/CBL-Mariner/  --RPM_storage https://az-storage-account.blob.core.windows.net/az-container/ --RPM_repo_file path/to/custom-repo-file --disable_mariner_repo
 ```
 
 ## Details on what goes on inside the container:
@@ -69,3 +72,14 @@ In the _interactive_ mode, it sets up the Mariner build system inside the contai
 
 ## Sample make commands:
 `make build-packages -j$(nproc)` would build specs under SPECS/ and populate out/ with the built SRPMs and RPMs
+
+## Sample custom repo:
+``` bash
+[custom-repo]
+name=Custom Repo
+baseurl=https://<IP Address>
+enabled=1
+gpgcheck=0
+skip_if_unavailable=False
+sslverify=0
+```

--- a/build-in-container/README.md
+++ b/build-in-container/README.md
@@ -15,8 +15,8 @@ The mariner-docker-builder.sh script presents these options <br />
 Optional arguments <br />
   --mariner_dir             directory to use for Mariner artifacts (SPECS, toolkit, ..). Default is the current directory <br />
   --RPM_repo_file           Path to a custom repo file. Please see [here](./README.md#sample-custom-repo) for sample custom repo file  <br />
-  --RPM_storage             URL of Azure blob storage to install RPMs from <br />
-  --disable_mariner_repo    Disable default Mariner RPM repos. They are enabled by default <br />
+  --RPM_container_URL       URL of Azure blob storage container to install RPMs from. Provide multiple URLs with comma (,) as delimiter <br />
+  --disable_mariner_repo    disable default setting to use default Mariner package repos on packages.microsoft.com <br />
 </pre>
 
 - 'tool_dir' refers to the directory of the build-in-container tool <br/>
@@ -41,8 +41,19 @@ ls out/RPMS/x86_64/
 #  Run the tools manually
 make build-packages SRPM_PACK_LIST="hello_world_demo" -j$(nproc)
 
-# Provide optional arguments
-./CBL-MarinerTutorials/mariner-docker-builder.sh -i --mariner_dir /path/to/CBL-Mariner/  --RPM_storage https://az-storage-account.blob.core.windows.net/az-container/ --RPM_repo_file path/to/custom-repo-file --disable_mariner_repo
+# Use optional arguments
+## Provide path to Mariner directory. If this option is not used, the current directory is treated as Mariner directory
+./CBL-MarinerTutorials/mariner-docker-builder.sh -i --mariner_dir /path/to/CBL-Mariner/
+
+## Install RPMs from a custom repo, by providing path to .repo file
+./CBL-MarinerTutorials/mariner-docker-builder.sh -i --RPM_repo_file path/to/custom-repo-file
+
+## Install RPMs from an Azure blob-storage container storing custom RPMs, by providing URL of the container. Provide multiple URLs with comma (,) as delimiter
+./CBL-MarinerTutorials/mariner-docker-builder.sh -i --RPM_container_URL https://az-storage-account.blob.core.windows.net/az-container/
+
+## Disable default setting to use default Mariner package repos on packages.microsoft.com
+./CBL-MarinerTutorials/mariner-docker-builder.sh -i --disable_mariner_repo
+
 ```
 
 ## Details on what goes on inside the container:

--- a/build-in-container/mariner-docker-builder.sh
+++ b/build-in-container/mariner-docker-builder.sh
@@ -22,8 +22,8 @@ help() {
     Optional arguments:
     --mariner_dir             directory to use for Mariner artifacts (SPECS, toolkit, ..). Default is the current directory
     --RPM_repo_file           Path to a custom repo file.
-    --RPM_storage             URL of Azure blob storage to install RPMs from.
-    --disable_mariner_repo    Disable default Mariner RPM repos. They are enabled by default.
+    --RPM_container_URL       URL of Azure blob storage container to install RPMs from. Provide multiple URLs with comma (,) as delimiter.
+    --disable_mariner_repo    Disable default setting to use default Mariner package repos on packages.microsoft.com
 
     * unless provided, mariner_dir defaults to the current directory
                         (default: $mariner_dir)
@@ -77,7 +77,7 @@ while (( "$#")); do
     -c ) cleanup; exit 0 ;;
     --mariner_dir ) mariner_dir="$(realpath $2)"; shift 2 ;;
     --RPM_repo_file ) enable_custom_repofile=true; cp $(realpath $2) $custom_repo_file; shift 2 ;;
-    --RPM_storage ) enable_custom_repo_storage=true; RPM_storage="$2"; shift 2 ;;
+    --RPM_container_URL ) enable_custom_repo_storage=true; RPM_container_URL="$2"; shift 2 ;;
     --disable_mariner_repo ) disable_mariner_repo=true; shift ;;
     --help ) help; exit 0 ;;
     ?* ) echo -e "ERROR: INVALID OPTION.\n\n"; help; exit 1 ;;

--- a/build-in-container/mariner-docker-builder.sh
+++ b/build-in-container/mariner-docker-builder.sh
@@ -21,7 +21,10 @@ help() {
 
     Optional arguments:
     --mariner_dir             directory to use for Mariner artifacts (SPECS, toolkit, ..). Default is the current directory
-    
+    --RPM_repo_file           Path to a custom repo file.
+    --RPM_storage             URL of Azure blob storage to install RPMs from.
+    --disable_mariner_repo    Disable default Mariner RPM repos. They are enabled by default.
+
     * unless provided, mariner_dir defaults to the current directory
                         (default: $mariner_dir)
     "
@@ -55,6 +58,10 @@ cleanup() {
 
 tool_dir=$( realpath "$(dirname "$0")" )
 mariner_dir=$(realpath "$(pwd)")
+disable_mariner_repo=false
+enable_custom_repofile=false
+enable_custom_repo_storage=false
+custom_repo_file=$tool_dir/scripts/custom-repo.repo
 
 if [ "$#" -eq 0 ]
 then
@@ -69,6 +76,9 @@ while (( "$#")); do
     -i ) container_type="interactive"; shift ;;
     -c ) cleanup; exit 0 ;;
     --mariner_dir ) mariner_dir="$(realpath $2)"; shift 2 ;;
+    --RPM_repo_file ) enable_custom_repofile=true; cp $(realpath $2) $custom_repo_file; shift 2 ;;
+    --RPM_storage ) enable_custom_repo_storage=true; RPM_storage="$2"; shift 2 ;;
+    --disable_mariner_repo ) disable_mariner_repo=true; shift ;;
     --help ) help; exit 0 ;;
     ?* ) echo -e "ERROR: INVALID OPTION.\n\n"; help; exit 1 ;;
   esac

--- a/build-in-container/run-container.sh
+++ b/build-in-container/run-container.sh
@@ -124,6 +124,9 @@ mount_pts="
     -v /sys:/sys:ro
     "
 
-container_args="--container_type $container_type"
+container_args="--disable_mariner_repo $disable_mariner_repo --enable_custom_repofile $enable_custom_repofile --enable_custom_repo_storage $enable_custom_repo_storage --container_type $container_type"
+if [[ "${enable_custom_repofile}" == "true" ]]; then container_args+=" --RPM_repo_file /mariner/scripts/custom-repo.repo"; fi
+if [[ "${enable_custom_repo_storage}" == "true" ]]; then container_args+=" --RPM_storage $RPM_storage"; fi
+
 if [ "$container_type" == "build" ]; then run_build_container; return; fi
 if [ "$container_type" == "interactive" ]; then run_interactive_container; return; fi

--- a/build-in-container/run-container.sh
+++ b/build-in-container/run-container.sh
@@ -126,7 +126,7 @@ mount_pts="
 
 container_args="--disable_mariner_repo $disable_mariner_repo --enable_custom_repofile $enable_custom_repofile --enable_custom_repo_storage $enable_custom_repo_storage --container_type $container_type"
 if [[ "${enable_custom_repofile}" == "true" ]]; then container_args+=" --RPM_repo_file /mariner/scripts/custom-repo.repo"; fi
-if [[ "${enable_custom_repo_storage}" == "true" ]]; then container_args+=" --RPM_storage $RPM_storage"; fi
+if [[ "${enable_custom_repo_storage}" == "true" ]]; then container_args+=" --RPM_container_URL $RPM_container_URL"; fi
 
 if [ "$container_type" == "build" ]; then run_build_container; return; fi
 if [ "$container_type" == "interactive" ]; then run_interactive_container; return; fi

--- a/build-in-container/scripts/build-mariner.sh
+++ b/build-in-container/scripts/build-mariner.sh
@@ -18,6 +18,51 @@ while (( "$#" )); do
             exit 1
         fi
         ;;
+        --RPM_repo_file)
+        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+            RPM_repo_file=$2
+            shift 2
+        else
+            echo "Error: Argument for $1 is missing" >&2
+            exit 1
+        fi
+        ;;
+        --RPM_storage)
+        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+            RPM_storage=$2
+            shift 2
+        else
+            echo "Error: Argument for $1 is missing" >&2
+            exit 1
+        fi
+        ;;
+        --enable_custom_repofile)
+        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+            enable_custom_repofile=$2
+            shift 2
+        else
+            echo "Error: Argument for $1 is missing" >&2
+            exit 1
+        fi
+        ;;
+        --enable_custom_repo_storage)
+        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+            enable_custom_repo_storage=$2
+            shift 2
+        else
+            echo "Error: Argument for $1 is missing" >&2
+            exit 1
+        fi
+        ;;
+        --disable_mariner_repo)
+        if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+            disable_mariner_repo=$2
+            shift 2
+        else
+            echo "Error: Argument for $1 is missing" >&2
+            exit 1
+        fi
+        ;;
         -*|--*=) # unsupported flags
         echo "Error: Unsupported flag $1" >&2
         exit 1

--- a/build-in-container/scripts/build-mariner.sh
+++ b/build-in-container/scripts/build-mariner.sh
@@ -27,9 +27,9 @@ while (( "$#" )); do
             exit 1
         fi
         ;;
-        --RPM_storage)
+        --RPM_container_URL)
         if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
-            RPM_storage=$2
+            RPM_container_URL=$2
             shift 2
         else
             echo "Error: Argument for $1 is missing" >&2

--- a/build-in-container/scripts/setup.sh
+++ b/build-in-container/scripts/setup.sh
@@ -69,19 +69,22 @@ setup_custom_repofile() {
 
 # enable custom blob storage to install RPMs from
 setup_custom_repo_storage() {
-    echo "------------ Setting up custom repo storage ------------"
+    echo "------------ Downloading RPMs from custom RPM blob storage container ------------"
     #install azcopy
     wget -O azcopy_v10.tar.gz https://aka.ms/downloadazcopy-v10-linux  || { echo "ERROR: Could not install azcopy"; exit 1; }
     tar -xf azcopy_v10.tar.gz --strip-components=1
     mv azcopy /bin/
     rm -rf azcopy* NOTICE.txt
 
-    #download all RPMs from Azure $RPM_storage to $MARINER_BASE_DIR/build/rpm_cache/cache
-    azcopy copy $RPM_storage/* $MARINER_BASE_DIR/build/rpm_cache/cache
+    for i in $(echo $RPM_container_URL | tr "," "\n")
+    do
+        #download all RPMs from Azure $RPM_container_URL to $MARINER_BASE_DIR/build/rpm_cache/cache
+        azcopy copy $RPM_container_URL/* $MARINER_BASE_DIR/build/rpm_cache/cache
+    done
 }
 
-# remove default Mariner RPM repos
-remove_mariner_repo() {
+# disable default Mariner RPM repos
+disable_mariner_default_repos() {
     echo "------------ Removing Mariner default repos ------------"
     DISABLE_DEFAULT_REPOS="y"
     export DISABLE_DEFAULT_REPOS
@@ -161,7 +164,7 @@ if [[ "${enable_custom_repofile}" == "true" ]]; then setup_custom_repofile; fi
 if [[ "${enable_custom_repo_storage}" == "true" ]]; then setup_custom_repo_storage; fi
 
 # disable Mariner repos if true
-if [[ "${disable_mariner_repo}" == "true" ]]; then remove_mariner_repo; fi
+if [[ "${disable_mariner_repo}" == "true" ]]; then disable_mariner_default_repos; fi
 
 # check if $SPECS_DIR is empty
 check_specs

--- a/build-in-container/scripts/setup.sh
+++ b/build-in-container/scripts/setup.sh
@@ -59,6 +59,34 @@ check_specs() {
     fi
 }
 
+# enable custom-repo.repo to install RPMs from
+setup_custom_repofile() {
+    echo "------------ Setting up custom repofile ------------"
+    echo -e "\n" >> $MARINER_BASE_DIR/toolkit/resources/manifests/package/local.repo
+    cat $RPM_repo_file >> $MARINER_BASE_DIR/toolkit/resources/manifests/package/local.repo
+    echo -e "\n" >> $MARINER_BASE_DIR/toolkit/resources/manifests/package/local.repo
+}
+
+# enable custom blob storage to install RPMs from
+setup_custom_repo_storage() {
+    echo "------------ Setting up custom repo storage ------------"
+    #install azcopy
+    wget -O azcopy_v10.tar.gz https://aka.ms/downloadazcopy-v10-linux  || { echo "ERROR: Could not install azcopy"; exit 1; }
+    tar -xf azcopy_v10.tar.gz --strip-components=1
+    mv azcopy /bin/
+    rm -rf azcopy* NOTICE.txt
+
+    #download all RPMs from Azure $RPM_storage to $MARINER_BASE_DIR/build/rpm_cache/cache
+    azcopy copy $RPM_storage/* $MARINER_BASE_DIR/build/rpm_cache/cache
+}
+
+# remove default Mariner RPM repos
+remove_mariner_repo() {
+    echo "------------ Removing Mariner default repos ------------"
+    DISABLE_DEFAULT_REPOS="y"
+    export DISABLE_DEFAULT_REPOS
+}
+
 # create chroot lock
 pushd $CHROOT_DIR
 touch chroot-pool.lock
@@ -125,6 +153,15 @@ go version
 pushd $MARINER_BASE_DIR
 download_mariner_toolkit
 popd
+
+# enable custom repo from file if true
+if [[ "${enable_custom_repofile}" == "true" ]]; then setup_custom_repofile; fi
+
+# enable custom repo from storage if true
+if [[ "${enable_custom_repo_storage}" == "true" ]]; then setup_custom_repo_storage; fi
+
+# disable Mariner repos if true
+if [[ "${disable_mariner_repo}" == "true" ]]; then remove_mariner_repo; fi
 
 # check if $SPECS_DIR is empty
 check_specs


### PR DESCRIPTION
This PR adds capability to use custom repos for installing RPMs while building packages:
- install RPMs from custom repo: enables ‘tdnf install’ from user-provided custom repofile
- install RPMs from custom Azure blob storage: asks the user for URL to Azure blob storage, 'wget's the RPMs stored in the blob storage to a local path and enables ‘tdnf install’ from there
- an option to disable mariner default repos