### PR TITLE
multiple custom-repo.repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /build-in-container/out
 /build-in-container/SPECS
 /build-in-container/toolkit
+/build-in-container/scripts/custom-repo.repo

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@
 /build-in-container/out
 /build-in-container/SPECS
 /build-in-container/toolkit
-/build-in-container/scripts/custom-repo.repo
+/build-in-container/scripts/custom_repos

--- a/build-in-container/README.md
+++ b/build-in-container/README.md
@@ -14,7 +14,7 @@ The mariner-docker-builder.sh script presents these options <br />
 
 Optional arguments <br />
   --mariner_dir             directory to use for Mariner artifacts (SPECS, toolkit, ..). Default is the current directory <br />
-  --RPM_repo_file           Path to a custom repo file (must end in .repo). Please see [here](./README.md#sample-custom-repo) for sample custom repo file  <br />
+  --RPM_repo_file           Path to custom repo file(s) (must end in .repo). Please see [here](./README.md#sample-custom-repo) for sample custom repo file. Provide multiple files with comma (,) as delimiter  <br />
   --RPM_container_URL       URL of Azure blob storage container to install RPMs from. Provide multiple URLs with comma (,) as delimiter <br />
   --disable_mariner_repo    disable default setting to use default Mariner package repos on packages.microsoft.com <br />
 </pre>

--- a/build-in-container/README.md
+++ b/build-in-container/README.md
@@ -41,9 +41,6 @@ ls out/RPMS/x86_64/
 #  Run the tools manually
 make build-packages SRPM_PACK_LIST="hello_world_demo" -j$(nproc)
 
-# Clean up Mariner workspace, and docker image and container
-./CBL-MarinerTutorials/mariner-docker-builder.sh --mariner_dir /path/to/CBL-Mariner -c
-
 # Use optional arguments
 ## Provide path to Mariner directory. If this option is not used, the current directory is treated as Mariner directory
 ./CBL-MarinerTutorials/mariner-docker-builder.sh -i --mariner_dir /path/to/CBL-Mariner/

--- a/build-in-container/README.md
+++ b/build-in-container/README.md
@@ -14,7 +14,7 @@ The mariner-docker-builder.sh script presents these options <br />
 
 Optional arguments <br />
   --mariner_dir             directory to use for Mariner artifacts (SPECS, toolkit, ..). Default is the current directory <br />
-  --RPM_repo_file           Path(s) to custom repo file(s) (must end in .repo). Please see [here](./README.md#sample-custom-repo) for sample custom repo file. Provide multiple files with space (" ") as delimiter  <br />
+  --RPM_repo_file           Path(s) to custom repo file(s) (must end in .repo). Please see [here](./README.md#sample-custom-repo) for sample custom repo file. Provide multiple files with space (" ") as delimiter. Please prefer RPM_repo_file over RPM_container_URL. <br />
   --RPM_container_URL       URL(s) of Azure blob storage container(s) to install RPMs from. Provide multiple URLs with space (" ") as delimiter <br />
   --disable_mariner_repo    disable default setting to use default Mariner package repos on packages.microsoft.com <br />
 </pre>

--- a/build-in-container/README.md
+++ b/build-in-container/README.md
@@ -14,8 +14,8 @@ The mariner-docker-builder.sh script presents these options <br />
 
 Optional arguments <br />
   --mariner_dir             directory to use for Mariner artifacts (SPECS, toolkit, ..). Default is the current directory <br />
-  --RPM_repo_file           Path to custom repo file(s) (must end in .repo). Please see [here](./README.md#sample-custom-repo) for sample custom repo file. Provide multiple files with comma (,) as delimiter  <br />
-  --RPM_container_URL       URL of Azure blob storage container to install RPMs from. Provide multiple URLs with comma (,) as delimiter <br />
+  --RPM_repo_file           Path(s) to custom repo file(s) (must end in .repo). Please see [here](./README.md#sample-custom-repo) for sample custom repo file. Provide multiple files with space (" ") as delimiter  <br />
+  --RPM_container_URL       URL(s) of Azure blob storage container(s) to install RPMs from. Provide multiple URLs with space (" ") as delimiter <br />
   --disable_mariner_repo    disable default setting to use default Mariner package repos on packages.microsoft.com <br />
 </pre>
 
@@ -47,10 +47,12 @@ make build-packages SRPM_PACK_LIST="hello_world_demo" -j$(nproc)
 
 ## Install RPMs from a custom repo, by providing path to .repo file
 ## Please ensure that custom repo file ends in '.repo' as per requirements of rpm/yum/tdnf/dnf
-./CBL-MarinerTutorials/mariner-docker-builder.sh -i --RPM_repo_file path/to/custom-repo-file.repo[,path/to/another-custom-repo-file.repo]
+## Provide multiple paths with space (" ") as delimiter
+./CBL-MarinerTutorials/mariner-docker-builder.sh -i --RPM_repo_file "path/to/custom-repo-file.repo[ path/to/another-custom-repo-file.repo]"
 
-## Install RPMs from an Azure blob-storage container storing custom RPMs, by providing URL of the container. Provide multiple URLs with comma (,) as delimiter
-./CBL-MarinerTutorials/mariner-docker-builder.sh -i --RPM_container_URL https://az-storage-account.blob.core.windows.net/az-container/[,https://az-storage-account.blob.core.windows.net/another-az-container/]
+## Install RPMs from an Azure blob-storage container storing custom RPMs, by providing URL of the container
+## Provide multiple URLs with space (" ") as delimiter
+./CBL-MarinerTutorials/mariner-docker-builder.sh -i --RPM_container_URL "https://az-storage-account.blob.core.windows.net/az-container/[ https://az-storage-account.blob.core.windows.net/another-az-container/]"
 
 ## Disable default setting to use default Mariner package repos on packages.microsoft.com
 ./CBL-MarinerTutorials/mariner-docker-builder.sh -i --disable_mariner_repo

--- a/build-in-container/README.md
+++ b/build-in-container/README.md
@@ -14,7 +14,7 @@ The mariner-docker-builder.sh script presents these options <br />
 
 Optional arguments <br />
   --mariner_dir             directory to use for Mariner artifacts (SPECS, toolkit, ..). Default is the current directory <br />
-  --RPM_repo_file           Path to a custom repo file. Please see [here](./README.md#sample-custom-repo) for sample custom repo file  <br />
+  --RPM_repo_file           Path to a custom repo file (must end in .repo). Please see [here](./README.md#sample-custom-repo) for sample custom repo file  <br />
   --RPM_container_URL       URL of Azure blob storage container to install RPMs from. Provide multiple URLs with comma (,) as delimiter <br />
   --disable_mariner_repo    disable default setting to use default Mariner package repos on packages.microsoft.com <br />
 </pre>
@@ -41,15 +41,19 @@ ls out/RPMS/x86_64/
 #  Run the tools manually
 make build-packages SRPM_PACK_LIST="hello_world_demo" -j$(nproc)
 
+# Clean up Mariner workspace, and docker image and container
+./CBL-MarinerTutorials/mariner-docker-builder.sh --mariner_dir /path/to/CBL-Mariner -c
+
 # Use optional arguments
 ## Provide path to Mariner directory. If this option is not used, the current directory is treated as Mariner directory
 ./CBL-MarinerTutorials/mariner-docker-builder.sh -i --mariner_dir /path/to/CBL-Mariner/
 
 ## Install RPMs from a custom repo, by providing path to .repo file
-./CBL-MarinerTutorials/mariner-docker-builder.sh -i --RPM_repo_file path/to/custom-repo-file
+## Please ensure that custom repo file ends in '.repo' as per requirements of rpm/yum/tdnf/dnf
+./CBL-MarinerTutorials/mariner-docker-builder.sh -i --RPM_repo_file path/to/custom-repo-file.repo[,path/to/another-custom-repo-file.repo]
 
 ## Install RPMs from an Azure blob-storage container storing custom RPMs, by providing URL of the container. Provide multiple URLs with comma (,) as delimiter
-./CBL-MarinerTutorials/mariner-docker-builder.sh -i --RPM_container_URL https://az-storage-account.blob.core.windows.net/az-container/
+./CBL-MarinerTutorials/mariner-docker-builder.sh -i --RPM_container_URL https://az-storage-account.blob.core.windows.net/az-container/[,https://az-storage-account.blob.core.windows.net/another-az-container/]
 
 ## Disable default setting to use default Mariner package repos on packages.microsoft.com
 ./CBL-MarinerTutorials/mariner-docker-builder.sh -i --disable_mariner_repo
@@ -84,7 +88,7 @@ In the _interactive_ mode, it sets up the Mariner build system inside the contai
 ## Sample make commands:
 `make build-packages -j$(nproc)` would build specs under SPECS/ and populate out/ with the built SRPMs and RPMs
 
-## Sample custom repo:
+## Sample custom repo: (custom-repo.repo)
 ``` bash
 [custom-repo]
 name=Custom Repo

--- a/build-in-container/mariner-docker-builder.sh
+++ b/build-in-container/mariner-docker-builder.sh
@@ -21,8 +21,8 @@ help() {
 
     Optional arguments:
     --mariner_dir             directory to use for Mariner artifacts (SPECS, toolkit, ..). Default is the current directory
-    --RPM_repo_file           Path to a custom repo file (must end in .repo). Provide multiple filepaths with comma (,) as delimiter.
-    --RPM_container_URL       URL of Azure blob storage container to install RPMs from. Provide multiple URLs with comma (,) as delimiter.
+    --RPM_repo_file           Path(s) to custom repo file(s) (must end in .repo). Provide multiple filepaths with space (" ") as delimiter.
+    --RPM_container_URL       URL(s) of Azure blob storage container(s) to install RPMs from. Provide multiple URLs with space (" ") as delimiter.
     --disable_mariner_repo    Disable default setting to use default Mariner package repos on packages.microsoft.com
 
     * unless provided, mariner_dir defaults to the current directory
@@ -104,7 +104,7 @@ while (( "$#")); do
     -c ) cleanup; exit 0 ;;
     --mariner_dir ) mariner_dir="$(realpath $2)"; shift 2 ;;
     --RPM_repo_file ) enable_custom_repofile=true; validate_custom_repo_file "$2"; copy_custom_repo_file "$2"; shift 2 ;;
-    --RPM_container_URL ) enable_custom_repo_storage=true; RPM_container_URL="$2"; shift 2 ;;
+    --RPM_container_URL ) enable_custom_repo_storage=true; RPM_container_URL=$(echo $2 | tr " " ","); shift 2 ;;
     --disable_mariner_repo ) disable_mariner_repo=true; shift ;;
     --help ) help; exit 0 ;;
     ?* ) echo -e "ERROR: INVALID OPTION.\n\n"; help; exit 1 ;;

--- a/build-in-container/mariner-docker-builder.sh
+++ b/build-in-container/mariner-docker-builder.sh
@@ -49,12 +49,7 @@ run_container() {
 cleanup() {
     echo "Cleaning up mariner artifacts at $mariner_dir ....."
     echo "This requires running as root ...."
-    #check if running as root, exit if not
-    if [ "$EUID" -ne 0 ]; then
-        echo -e "\033[31mExiting. Please run as root\033[0m "
-    exit
-    fi
-    rm -rf ${mariner_dir}/build ${mariner_dir}/ccache ${mariner_dir}/logs ${mariner_dir}/out ${mariner_dir}/toolkit
+    sudo rm -rf ${mariner_dir}/build ${mariner_dir}/ccache ${mariner_dir}/logs ${mariner_dir}/out ${mariner_dir}/toolkit
     # remove Mariner docker containers
     docker rm -f $(docker ps -aq --filter ancestor="mcr.microsoft.com/mariner-container-build:2.0")
     # remove Mariner docker images
@@ -70,7 +65,7 @@ create_custom_repo_file() {
     done
 }
 
-tool_dir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
+tool_dir=$( realpath "$(dirname "$0")" )
 mariner_dir=$(realpath "$(pwd)")
 disable_mariner_repo=false
 enable_custom_repofile=false

--- a/build-in-container/mariner-docker-builder.sh
+++ b/build-in-container/mariner-docker-builder.sh
@@ -59,27 +59,26 @@ cleanup() {
 copy_custom_repo_file() {
     RPM_repo_file=
     mkdir -p $tool_dir/scripts/custom_repos
-    for repo_file in $(echo $1 | tr " " "\n")
+    for repo_file in $1
     do
         repo_file_name=${repo_file##*/} # remove prefix ending in '/'
         cp $(realpath $repo_file) $tool_dir/scripts/custom_repos/$repo_file_name # copy repo_file inside container
-        RPM_repo_file+="/mariner/scripts/custom_repos/$repo_file_name,"
+        RPM_repo_file+="/mariner/scripts/custom_repos/$repo_file_name "
     done
 }
 
 validate_custom_repo_file() {
-    for repo_file in $(echo $1 | tr " " "\n")
+    for repo_file in $1
     do
         # exit if $repo_file doesn't exist
-        echo "repo_file is $repo_file"
         if [[ ! -f $(realpath $repo_file) ]]; then
             echo -e "-------- \033[31m ALERT: $repo_file doesn't exist. Exiting\033[0m --------"
-            exit
+            exit 1
         fi
         # exit if $repo_file doesn't end in '.repo'
         if [[ $repo_file != *.repo ]]; then
             echo -e "-------- \033[31m ALERT:$repo_file name must end in '.repo'. Exiting\033[0m --------"
-            exit
+            exit 1
         fi
     done
 }
@@ -104,7 +103,7 @@ while (( "$#")); do
     -c ) cleanup; exit 0 ;;
     --mariner_dir ) mariner_dir="$(realpath $2)"; shift 2 ;;
     --RPM_repo_file ) enable_custom_repofile=true; validate_custom_repo_file "$2"; copy_custom_repo_file "$2"; shift 2 ;;
-    --RPM_container_URL ) enable_custom_repo_storage=true; RPM_container_URL=$(echo $2 | tr " " ","); shift 2 ;;
+    --RPM_container_URL ) enable_custom_repo_storage=true; RPM_container_URL="$2"; shift 2 ;;
     --disable_mariner_repo ) disable_mariner_repo=true; shift ;;
     --help ) help; exit 0 ;;
     ?* ) echo -e "ERROR: INVALID OPTION.\n\n"; help; exit 1 ;;

--- a/build-in-container/run-container.sh
+++ b/build-in-container/run-container.sh
@@ -25,7 +25,7 @@ run_interactive_container() {
         ${mount_pts} \
         --privileged \
         --cap-add SYS_ADMIN \
-        -it mcr.microsoft.com/mariner-container-build:2.0 /mariner/scripts/build-mariner.sh $container_args
+        -it mcr.microsoft.com/mariner-container-build:2.0 bash -c "/mariner/scripts/build-mariner.sh $container_args"
 }
 
 mount_pts="
@@ -125,8 +125,8 @@ mount_pts="
     "
 
 container_args="--disable_mariner_repo $disable_mariner_repo --enable_custom_repofile $enable_custom_repofile --enable_custom_repo_storage $enable_custom_repo_storage --container_type $container_type"
-if [[ "${enable_custom_repofile}" == "true" ]]; then container_args+=" --RPM_repo_file $RPM_repo_file"; fi
-if [[ "${enable_custom_repo_storage}" == "true" ]]; then container_args+=" --RPM_container_URL $RPM_container_URL"; fi
+if [[ "${enable_custom_repofile}" == "true" ]]; then container_args+=" --RPM_repo_file '$RPM_repo_file' "; fi
+if [[ "${enable_custom_repo_storage}" == "true" ]]; then container_args+=" --RPM_container_URL '$RPM_container_URL' "; fi
 
 if [ "$container_type" == "build" ]; then run_build_container; return; fi
 if [ "$container_type" == "interactive" ]; then run_interactive_container; return; fi

--- a/build-in-container/run-container.sh
+++ b/build-in-container/run-container.sh
@@ -17,7 +17,7 @@ run_build_container() {
         ${mount_pts} \
         --privileged \
         --cap-add SYS_ADMIN \
-        mcr.microsoft.com/mariner-container-build:2.0 /mariner/scripts/build-mariner.sh $container_args
+        mcr.microsoft.com/mariner-container-build:2.0 bash -c "/mariner/scripts/build-mariner.sh $container_args"
 }
 
 run_interactive_container() {

--- a/build-in-container/run-container.sh
+++ b/build-in-container/run-container.sh
@@ -125,7 +125,7 @@ mount_pts="
     "
 
 container_args="--disable_mariner_repo $disable_mariner_repo --enable_custom_repofile $enable_custom_repofile --enable_custom_repo_storage $enable_custom_repo_storage --container_type $container_type"
-if [[ "${enable_custom_repofile}" == "true" ]]; then container_args+=" --RPM_repo_file /mariner/scripts/custom-repo.repo"; fi
+if [[ "${enable_custom_repofile}" == "true" ]]; then container_args+=" --RPM_repo_file $RPM_repo_file"; fi
 if [[ "${enable_custom_repo_storage}" == "true" ]]; then container_args+=" --RPM_container_URL $RPM_container_URL"; fi
 
 if [ "$container_type" == "build" ]; then run_build_container; return; fi

--- a/build-in-container/scripts/build-mariner.sh
+++ b/build-in-container/scripts/build-mariner.sh
@@ -78,7 +78,7 @@ source /mariner/scripts/setup.sh
 
 if [[ "${container_type}" == "build" ]]; then
     # exit if SPECS/ is empty
-    if [ ! "$(ls -A $SPECS_DIR)" ]; then exit 1; fi
+    if [ ! "$(ls -A $SPECS_DIR)" ]; then exit; fi
     source /mariner/scripts/build.sh
 else
     /bin/bash

--- a/build-in-container/scripts/build-mariner.sh
+++ b/build-in-container/scripts/build-mariner.sh
@@ -6,6 +6,16 @@
 set -e
 set -x
 
+# arguments:
+#
+# --container_type             : container type is either 'build' or 'interactive'
+# --RPM_repo_file              : path to custom repo file
+# --RPM_container_URL          : comma delimited URLs to Azure containers with RPMs
+# --enable_custom_repofile     : enable installing RPMs from repo(s) listed in RPM_repo_file, if true
+# --enable_custom_repo_storage : enable installing RPMs from container(s) in RPM_container_URL, if true
+# --disable_mariner_repo       : disable installing RPMs from default Mariner PMC, if true
+#
+
 # parse args passed to container
 while (( "$#" )); do
     case "$1" in
@@ -73,8 +83,11 @@ done
 source /mariner/scripts/setup.sh
 
 if [[ "${container_type}" == "build" ]]; then
-    # exit if SPECS/ is empty
-    if [ ! "$(ls -A $SPECS_DIR)" ]; then exit; fi
+    # exit if SPECS/ is empty && container_type is build as there is nothing to be done
+    if [ ! "$(ls -A $SPECS_DIR)" ]; then
+        echo -e "-------- \033[31m ALERT: Exiting the build container, found no specs to build \033[0m --------"
+        exit
+    fi
     source /mariner/scripts/build.sh
 else
     /bin/bash

--- a/build-in-container/scripts/build-mariner.sh
+++ b/build-in-container/scripts/build-mariner.sh
@@ -74,9 +74,7 @@ source /mariner/scripts/setup.sh
 
 if [[ "${container_type}" == "build" ]]; then
     # exit if SPECS/ is empty
-    if [ ! "$(ls -A $SPECS_DIR)" ]; then
-        exit
-    fi
+    if [ ! "$(ls -A $SPECS_DIR)" ]; then exit; fi
     source /mariner/scripts/build.sh
 else
     /bin/bash

--- a/build-in-container/scripts/build-mariner.sh
+++ b/build-in-container/scripts/build-mariner.sh
@@ -78,7 +78,7 @@ source /mariner/scripts/setup.sh
 
 if [[ "${container_type}" == "build" ]]; then
     # exit if SPECS/ is empty
-    if [ ! "$(ls -A $SPECS_DIR)" ]; then exit; fi
+    if [ ! "$(ls -A $SPECS_DIR)" ]; then exit 1; fi
     source /mariner/scripts/build.sh
 else
     /bin/bash

--- a/build-in-container/scripts/build-mariner.sh
+++ b/build-in-container/scripts/build-mariner.sh
@@ -67,6 +67,10 @@ while (( "$#" )); do
         echo "Error: Unsupported flag $1" >&2
         exit 1
         ;;
+        *) # unsupported argument
+        echo "Error: Unsupported argument $1" >&2
+        exit 1
+        ;;
     esac
 done
 

--- a/build-in-container/scripts/build-mariner.sh
+++ b/build-in-container/scripts/build-mariner.sh
@@ -6,16 +6,6 @@
 set -e
 set -x
 
-# arguments:
-#
-# --container_type             : container type is either 'build' or 'interactive'
-# --RPM_repo_file              : path to custom repo file
-# --RPM_container_URL          : comma delimited URLs to Azure containers with RPMs
-# --enable_custom_repofile     : enable installing RPMs from repo(s) listed in RPM_repo_file, if true
-# --enable_custom_repo_storage : enable installing RPMs from container(s) in RPM_container_URL, if true
-# --disable_mariner_repo       : disable installing RPMs from default Mariner PMC, if true
-#
-
 # parse args passed to container
 while (( "$#" )); do
     case "$1" in
@@ -83,9 +73,8 @@ done
 source /mariner/scripts/setup.sh
 
 if [[ "${container_type}" == "build" ]]; then
-    # exit if SPECS/ is empty && container_type is build as there is nothing to be done
+    # exit if SPECS/ is empty
     if [ ! "$(ls -A $SPECS_DIR)" ]; then
-        echo -e "-------- \033[31m ALERT: Exiting the build container, found no specs to build \033[0m --------"
         exit
     fi
     source /mariner/scripts/build.sh

--- a/build-in-container/scripts/setup.sh
+++ b/build-in-container/scripts/setup.sh
@@ -62,7 +62,13 @@ check_specs() {
 # enable custom-repo.repo to install RPMs from
 setup_custom_repofile() {
     echo "------------ Setting up custom repofile ------------"
-    for repo_file in $(echo $RPM_repo_file | tr "," "\n")
+    
+    # get default value of PACKAGE_URL_LIST from Mariner Makefile
+    pushd $MARINER_BASE_DIR/toolkit 
+    PACKAGE_URL_LIST=$(make printvar-PACKAGE_URL_LIST 2>/dev/null)
+    popd
+
+    for repo_file in $RPM_repo_file
     do
         # append baseurl from $repo_file to $PACKAGE_LIST_URL to use them for downloading toolchain RPMs
         PACKAGE_URL_LIST+=" "
@@ -86,7 +92,7 @@ setup_custom_repo_storage() {
 
     # get architecture of the machine this container is running on
     arch=$(uname -m)
-    for container_URL in $(echo $RPM_container_URL | tr "," "\n")
+    for container_URL in $RPM_container_URL
     do
         #download all RPMs from $container_URL to use in package building
         azcopy copy $container_URL/* $MARINER_BASE_DIR/build/rpm_cache/cache

--- a/build-in-container/scripts/setup.sh
+++ b/build-in-container/scripts/setup.sh
@@ -75,8 +75,6 @@ setup_custom_repofile() {
 setup_custom_repo_storage() {
     echo "------------ Downloading RPMs from custom RPM blob storage container ------------"
     # install azcopy
-    # https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10#download-azcopy suggests taking dependency on
-    # specific version so future updates to azcopy don't break our tool
     wget -O azcopy_v10.tar.gz https://aka.ms/downloadazcopy-v10-linux  || { echo "ERROR: Could not install azcopy"; exit 1; }
     tar -xf azcopy_v10.tar.gz --strip-components=1
     mv azcopy /bin/

--- a/build-in-container/scripts/setup.sh
+++ b/build-in-container/scripts/setup.sh
@@ -71,15 +71,17 @@ setup_custom_repofile() {
 setup_custom_repo_storage() {
     echo "------------ Downloading RPMs from custom RPM blob storage container ------------"
     #install azcopy
+    # https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10#download-azcopy suggests taking dependency on
+    # specific version so future updates to azcopy don't break our tool
     wget -O azcopy_v10.tar.gz https://aka.ms/downloadazcopy-v10-linux  || { echo "ERROR: Could not install azcopy"; exit 1; }
     tar -xf azcopy_v10.tar.gz --strip-components=1
     mv azcopy /bin/
     rm -rf azcopy* NOTICE.txt
 
-    for i in $(echo $RPM_container_URL | tr "," "\n")
+    for container_URL in $(echo $RPM_container_URL | tr "," "\n")
     do
         #download all RPMs from Azure $RPM_container_URL to $MARINER_BASE_DIR/build/rpm_cache/cache
-        azcopy copy $RPM_container_URL/* $MARINER_BASE_DIR/build/rpm_cache/cache
+        azcopy copy $container_URL/* $MARINER_BASE_DIR/build/rpm_cache/cache
     done
 }
 


### PR DESCRIPTION
Major Changes:

User facing:
1. Allow multiple comma delimited custom-repo files
(gives user more freedom)
2. Urge user to name custom-repo files ending in '.repo'
(to avoid errors with dnf/tdnf/yum/rpm)

Backend:
1. Use PACKAGE_URL_LIST to enable using custom-repo.repo for toolchain RPMs
2. USE REPO_LIST to enable using custom-repo.repo for package building
(Earlier we were appending the contents of custom-repo.repo to local.repo. Using Mariner macros is cleaner, avoids duplication, and makes code more maintainable)
(Allow using RPMs from these custom repos as toolchain RPMs. The user should not have to worry about the distinction between toolchain and non-toolchain RPMs)
4. Enable handling multiple comma delimited custom-repo files
5. Download RPMs from RPM_container_URL and use them as toolchain RPMs
(earlier they were only downloaded for RPMs used in package building. The user should not have to worry about the distinction between toolchain and non-toolchain RPMs)

Test:
1. Disabled Mariner default repos. Package build failed as package dependencies could not be satisfied.
2. Disabled Mariner default repos. Added mariner-official-base repo as a custom repo under a different name. Package build succeeded.
3. Disabled Mariner default repos. Uploaded package dependencies to Azure blob storage. Package build succeeded.

The above changes were discussed in comments on previous PRs:
- https://github.com/microsoft/CBL-MarinerTutorials/pull/45
- https://github.com/microsoft/CBL-MarinerTutorials/pull/46
- Suggestion not considered: didn't rename RPM_container_URL to minimize user facing changes