### PR TITLE
use bashsource to set tool_dir

### DIFF
--- a/build-in-container/mariner-docker-builder.sh
+++ b/build-in-container/mariner-docker-builder.sh
@@ -88,7 +88,7 @@ validate_custom_repo_file() {
     done
 }
 
-tool_dir=$( realpath "$(dirname "$0")" )
+tool_dir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
 mariner_dir=$(realpath "$(pwd)")
 disable_mariner_repo=false
 enable_custom_repofile=false


### PR DESCRIPTION
Use bashsource to set tool_dir instead of $0 as it is more accurate, especially if sourcing the shell script.
Ref: https://kb.novaordis.com/index.php/Bash_Built-In_Variables#BASH_SOURCE