### PR TITLE
build-in-container: verify docker container env, exit if not

### DIFF
--- a/build-in-container/scripts/build.sh
+++ b/build-in-container/scripts/build.sh
@@ -93,6 +93,13 @@ publish_build_logs() {
 # main
 #
 
+# verify that we're running inside a container, exit if not
+if [[ ! -f /.dockerenv ]]; then
+    echo -e "\033[31mERROR: This script must be run in a container as it uses chroot. Please use mariner-docker-builder.sh\033[0m"
+    exit 1
+fi
+echo "------------ Verified that we are inside a docker container. Proceeding with build ------------"
+
 trap cleanup EXIT
 
 echo "-- BUILD_DIR                          -> $BUILD_DIR"

--- a/build-in-container/scripts/setup.sh
+++ b/build-in-container/scripts/setup.sh
@@ -5,6 +5,13 @@
 
 echo "------------ Setting up Mariner Build Environment ------------"
 
+# verify that we're running inside a container, exit if not
+if [[ ! -f /.dockerenv ]]; then
+    echo -e "\033[31mERROR: This script must be run in a container as it uses chroot. Please use mariner-docker-builder.sh\033[0m"
+    exit 1
+fi
+echo "------------ Verified that we are inside a docker container. Proceeding with setup ------------"
+
 # build variables
 MARINER_BASE_DIR=/mariner
 BUILD_DIR="$MARINER_BASE_DIR/build"


### PR DESCRIPTION
The scripts, setup.sh and build.sh, utilise chroot to setup mariner build system and build packages. If not invoked from within a container env, they can destablise the system, by directly modifying / directories.
This PR adds a check for both the scripts, to see if they are being run inside a docker environment, and exits with a error message if not.