### PR TITLE
Fix prerequisites for golang and remove 1.0.

### DIFF
--- a/docs/getting_started/prepare_environment.md
+++ b/docs/getting_started/prepare_environment.md
@@ -16,7 +16,7 @@ sudo add-apt-repository ppa:longsleep/golang-backports
 sudo apt-get update
 
 # Install required dependencies.
-sudo apt -y install git make tar wget curl rpm qemu-utils golang-1.17-go genisoimage python bison gawk
+sudo apt -y install git make tar wget curl rpm qemu-utils golang-1.20-go genisoimage python bison gawk
 
 # Recommended but not required: `pigz` for faster compression operations.
 sudo apt -y install pigz
@@ -34,17 +34,7 @@ sudo usermod -aG docker $USER
 
 ## Clone CBL-Mariner and Build the Toolkit
 
-To build the CBL-MarinerTutorials repository you will need the same toolkit and makefile from the CBL-Mariner repository.  So, first clone CBL-Mariner, and then checkout the stable release of interest (e.g. 1.0-stable or 2.0-stable), then build the toolkit.
-
-### Example for CBL-Mariner 1.0 Toolkit
-
-```bash
-git clone https://github.com/microsoft/CBL-Mariner.git
-pushd CBL-Mariner/toolkit
-git checkout 1.0-stable
-sudo make package-toolkit REBUILD_TOOLS=y
-popd
-```
+To build the CBL-MarinerTutorials repository you will need the same toolkit and makefile from the CBL-Mariner repository.  So, first clone CBL-Mariner, and then checkout the stable release of interest (e.g. 2.0-stable), then build the toolkit.
 
 ### Example for CBL-Mariner 2.0 Toolkit
 
@@ -69,4 +59,3 @@ tar -xzvf toolkit-*.tar.gz
 
 The toolkit folder now contains the makefile, support scripts and the go tools compiled from the section.  The toolkit will preserve the previously compiled tool binaries, however the toolkit is also able to rebuild them if desired. (Not recommended: set `REBUILD_TOOLS=y` to use locally rebuilt tool binaries during a build). For more information on our toolkit see [How The Build System Works](https://github.com/microsoft/CBL-Mariner/blob/-/toolkit/docs/how_it_works/0_intro.md) in the CBL-Mariner repo.  
 
-The remainder of this tutorial assumes you are using CBL-Mariner 2.0.  However, it is possible to build the same from this tutorial using the CBL-Mariner 1.0 release as well.


### PR DESCRIPTION
Two changes combined here.  The prerequisites for Mariner 2.0 golang were upgraded due to a breaking change in the toolkit. 

Mariner 1.0 is no longer supported, so this change removes that discussion